### PR TITLE
feat: add mode of inheritance from HPO

### DIFF
--- a/protos/varfish/v1/seqvars/output.proto
+++ b/protos/varfish/v1/seqvars/output.proto
@@ -191,7 +191,7 @@ message GeneRelatedPhenotypes {
   // Whether is a known disease gene.
   bool is_disease_gene = 2;
   // Linked modes of inheritance.
-  repeated ModeOfInheritance modes_of_inheritance = 3;
+  repeated ModeOfInheritance mode_of_inheritances = 3;
 }
 
 // Gene-wise constraints.

--- a/protos/varfish/v1/seqvars/output.proto
+++ b/protos/varfish/v1/seqvars/output.proto
@@ -166,12 +166,32 @@ message GeneRelatedConsequences {
   repeated varfish.v1.seqvars.query.Consequence consequences = 3;
 }
 
+// Enumerations with modes of inheritance from HPO.
+enum ModeOfInheritance {
+  // Unspecified mode of inheritance.
+  MODE_OF_INHERITANCE_UNSPECIFIED = 0;
+  // Autosomal dominant inheritance (HP:0000006).
+  MODE_OF_INHERITANCE_AUTOSOMAL_DOMINANT = 1;
+  // Autosomal recessive inheritance (HP:0000007).
+  MODE_OF_INHERITANCE_AUTOSOMAL_RECESSIVE = 2;
+  // X-linked dominant inheritance (HP:0001419).
+  MODE_OF_INHERITANCE_X_LINKED_DOMINANT = 3;
+  // X-linked recessive inheritance (HP:0001423).
+  MODE_OF_INHERITANCE_X_LINKED_RECESSIVE = 4;
+  // Y-linked inheritance (HP:0001450).
+  MODE_OF_INHERITANCE_Y_LINKED = 5;
+  // Mitochondrial inheritance (HP:0001427).
+  MODE_OF_INHERITANCE_MITOCHONDRIAL = 6;
+}
+
 // Phenotype-related information, if any.
 message GeneRelatedPhenotypes {
   // ACMG supplementary finding list.
   bool is_acmg_sf = 1;
   // Whether is a known disease gene.
   bool is_disease_gene = 2;
+  // Linked modes of inheritance.
+  repeated ModeOfInheritance modes_of_inheritance = 3;
 }
 
 // Gene-wise constraints.

--- a/src/seqvars/query/hpo.rs
+++ b/src/seqvars/query/hpo.rs
@@ -88,10 +88,10 @@ pub fn load_hgnc_to_inheritance_map<P: AsRef<std::path::Path>>(
                     if let Some(mode_of_inheritance) =
                         ModeOfInheritance::from_hpo_id(&ptg_entry.hpo_id)
                     {
-                        let modes_of_inheritance = result
+                        let mode_of_inheritances = result
                             .entry(hgnc_id.clone())
                             .or_insert_with(indexmap::IndexSet::new);
-                        modes_of_inheritance.insert_sorted(mode_of_inheritance);
+                        mode_of_inheritances.insert_sorted(mode_of_inheritance);
                     }
                 }
             }

--- a/src/seqvars/query/hpo.rs
+++ b/src/seqvars/query/hpo.rs
@@ -1,0 +1,315 @@
+//! Code for accessing HPO-related information.
+
+use crate::pbs::varfish::v1::seqvars::output as pbs_output;
+
+/// Enumeration for modes of inheritance.
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    enum_map::Enum,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Clone,
+    Copy,
+    Debug,
+    strum::EnumString,
+    strum::Display,
+)]
+pub enum ModeOfInheritance {
+    /// Autosomal dominant inheritance (HP:0000006).
+    AutosomalDominant,
+    /// Autosomal recessive inheritance (HP:0000007).
+    AutosomalRecessive,
+    /// X-linked dominant inheritance (HP:0001419).
+    XLinkedDominant,
+    /// X-linked recessive inheritance (HP:0001423).
+    XLinkedRecessive,
+    /// Y-linked inheritance (HP:0001450).
+    YLinked,
+    /// Mitochondrial inheritance (HP:0001427).
+    Mitochondrial,
+}
+
+impl ModeOfInheritance {
+    /// Allow parsing of `ModeOfInheritance` from HPO ID.
+    pub fn from_hpo_id(hpo_id: &str) -> Option<Self> {
+        match hpo_id {
+            "HP:0000006" | "HP:0012275" => Some(Self::AutosomalDominant),
+            "HP:0000007" => Some(Self::AutosomalRecessive),
+            "HP:0001419" => Some(Self::XLinkedDominant),
+            "HP:0001423" => Some(Self::XLinkedRecessive),
+            "HP:0001450" => Some(Self::YLinked),
+            "HP:0001427" => Some(Self::Mitochondrial),
+            _ => None,
+        }
+    }
+}
+
+impl From<ModeOfInheritance> for pbs_output::ModeOfInheritance {
+    fn from(val: ModeOfInheritance) -> Self {
+        match val {
+            ModeOfInheritance::AutosomalDominant => {
+                pbs_output::ModeOfInheritance::AutosomalDominant
+            }
+            ModeOfInheritance::AutosomalRecessive => {
+                pbs_output::ModeOfInheritance::AutosomalRecessive
+            }
+            ModeOfInheritance::XLinkedDominant => pbs_output::ModeOfInheritance::XLinkedDominant,
+            ModeOfInheritance::XLinkedRecessive => pbs_output::ModeOfInheritance::XLinkedRecessive,
+            ModeOfInheritance::YLinked => pbs_output::ModeOfInheritance::YLinked,
+            ModeOfInheritance::Mitochondrial => pbs_output::ModeOfInheritance::Mitochondrial,
+        }
+    }
+}
+
+pub type HgncToMoiMap = indexmap::IndexMap<String, indexmap::IndexSet<ModeOfInheritance>>;
+
+/// Load the the `phenotype_to_genes.tsv` and `hgnc_xlink.tsv` files from the `hpo`
+/// directory and build a map from HGNC gene ID to set of `ModeOfInheritance`
+/// values.
+pub fn load_hgnc_to_inheritance_map<P: AsRef<std::path::Path>>(
+    path: &P,
+) -> Result<HgncToMoiMap, anyhow::Error> {
+    let phenotypes_to_genes =
+        phenotype_to_genes::load_entries(&path.as_ref().join("phenotype_to_genes.txt"))
+            .map_err(|e| anyhow::anyhow!("error loading phenotype_to_genes.txt: {}", e))?;
+    let ncbi_to_hgnc = hgnc_xlink::load_ncbi_to_hgnc(path.as_ref().join("hgnc_xlink.tsv"))
+        .map_err(|e| anyhow::anyhow!("error loading hgnc_xlink.tsv: {}", e))?;
+
+    let mut result = indexmap::IndexMap::new();
+
+    for ptg_entry in phenotypes_to_genes {
+        if let Some(ncbi_gene_id) = ptg_entry.ncbi_gene_id {
+            if let Some(hgnc_ids) = ncbi_to_hgnc.get(&ncbi_gene_id) {
+                for hgnc_id in hgnc_ids {
+                    if let Some(mode_of_inheritance) =
+                        ModeOfInheritance::from_hpo_id(&ptg_entry.hpo_id)
+                    {
+                        let modes_of_inheritance = result
+                            .entry(hgnc_id.clone())
+                            .or_insert_with(indexmap::IndexSet::new);
+                        modes_of_inheritance.insert_sorted(mode_of_inheritance);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Code for accessing the `phenotype_to_genes.tsv` file.
+pub(super) mod phenotype_to_genes {
+    /// Data structure for representing an entry of the table.
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    #[serde_with::skip_serializing_none]
+    pub struct Entry {
+        /// Entrez gene ID.
+        #[serde(alias = "entrez_id")]
+        pub ncbi_gene_id: Option<u32>,
+        /// Gene symbol.
+        pub gene_symbol: String,
+        /// HPO ID.
+        pub hpo_id: String,
+        // HPO Name.
+        pub hpo_name: String,
+    }
+
+    /// Read the `phenotype_to_genes.tsv` file using the `csv` crate via serde.
+    ///
+    /// # Errors
+    ///
+    /// In the case that the file could not be read.
+    pub fn load_entries<P: AsRef<std::path::Path>>(path: &P) -> Result<Vec<Entry>, anyhow::Error> {
+        let mut rdr = csv::ReaderBuilder::new()
+            .delimiter(b'\t')
+            .has_headers(true)
+            .from_path(path.as_ref())?;
+        let mut entries = Vec::new();
+        for result in rdr.deserialize() {
+            let entry: Entry = result?;
+            entries.push(entry);
+        }
+        Ok(entries)
+    }
+}
+
+/// Code for accessing the `hgnc_xlink.tsv` file.
+pub(super) mod hgnc_xlink {
+    use std::collections::HashMap;
+
+    /// Data structure for representing an entry of the table.
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    #[serde_with::skip_serializing_none]
+    pub struct Entry {
+        /// HGNC gene ID.
+        pub hgnc_id: String,
+        /// Ensembl gene ID.
+        pub ensembl_gene_id: Option<String>,
+        /// Entrez gene ID.
+        #[serde(alias = "entrez_id")]
+        pub ncbi_gene_id: Option<u32>,
+        /// Gene symbol.
+        pub gene_symbol: String,
+    }
+
+    /// Read the `hgnc_xlink.tsv` file using the `csv` crate via serde.
+    ///
+    /// # Errors
+    ///
+    /// In the case that the file could not be read.
+    pub fn load_entries<P: AsRef<std::path::Path>>(path: &P) -> Result<Vec<Entry>, anyhow::Error> {
+        let mut rdr = csv::ReaderBuilder::new()
+            .delimiter(b'\t')
+            .has_headers(true)
+            .from_path(path.as_ref())?;
+        let mut entries = Vec::new();
+        for result in rdr.deserialize() {
+            let entry: Entry = result?;
+            entries.push(entry);
+        }
+        Ok(entries)
+    }
+
+    /// Read the `hgnc_xlink.tsv` into a map from NCBI gene ID to HGNC gene ID.
+    ///
+    /// # Errors
+    ///
+    /// In the case that the file could not be read.
+    pub fn load_ncbi_to_hgnc<P: AsRef<std::path::Path>>(
+        path: P,
+    ) -> Result<HashMap<u32, Vec<String>>, anyhow::Error> {
+        let mut map = HashMap::new();
+        for entry in load_entries(&path)? {
+            if let Some(ncbi_gene_id) = entry.ncbi_gene_id {
+                let hgnc_id = entry.hgnc_id;
+                let entry = map.entry(ncbi_gene_id).or_insert_with(Vec::new);
+                entry.push(hgnc_id);
+            }
+        }
+        Ok(map)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    pub fn test_mode_of_inheritance_from_hpo_id() {
+        assert_eq!(
+            super::ModeOfInheritance::from_hpo_id("HP:0000006"),
+            Some(super::ModeOfInheritance::AutosomalDominant)
+        );
+        assert_eq!(
+            super::ModeOfInheritance::from_hpo_id("HP:0012275"),
+            Some(super::ModeOfInheritance::AutosomalDominant)
+        );
+        assert_eq!(
+            super::ModeOfInheritance::from_hpo_id("HP:0000007"),
+            Some(super::ModeOfInheritance::AutosomalRecessive)
+        );
+        assert_eq!(
+            super::ModeOfInheritance::from_hpo_id("HP:0001419"),
+            Some(super::ModeOfInheritance::XLinkedDominant)
+        );
+        assert_eq!(
+            super::ModeOfInheritance::from_hpo_id("HP:0001423"),
+            Some(super::ModeOfInheritance::XLinkedRecessive)
+        );
+        assert_eq!(
+            super::ModeOfInheritance::from_hpo_id("HP:0001450"),
+            Some(super::ModeOfInheritance::YLinked)
+        );
+        assert_eq!(
+            super::ModeOfInheritance::from_hpo_id("HP:0001427"),
+            Some(super::ModeOfInheritance::Mitochondrial)
+        );
+
+        assert_eq!(super::ModeOfInheritance::from_hpo_id("HP:0000000"), None);
+    }
+
+    #[test]
+    pub fn test_mode_of_inheritance_into_pbs() {
+        assert_eq!(
+            Into::<super::pbs_output::ModeOfInheritance>::into(
+                super::ModeOfInheritance::AutosomalDominant
+            ),
+            super::pbs_output::ModeOfInheritance::AutosomalDominant
+        );
+        assert_eq!(
+            Into::<super::pbs_output::ModeOfInheritance>::into(
+                super::ModeOfInheritance::AutosomalRecessive
+            ),
+            super::pbs_output::ModeOfInheritance::AutosomalRecessive
+        );
+        assert_eq!(
+            Into::<super::pbs_output::ModeOfInheritance>::into(
+                super::ModeOfInheritance::XLinkedDominant
+            ),
+            super::pbs_output::ModeOfInheritance::XLinkedDominant
+        );
+        assert_eq!(
+            Into::<super::pbs_output::ModeOfInheritance>::into(
+                super::ModeOfInheritance::XLinkedRecessive
+            ),
+            super::pbs_output::ModeOfInheritance::XLinkedRecessive
+        );
+        assert_eq!(
+            Into::<super::pbs_output::ModeOfInheritance>::into(super::ModeOfInheritance::YLinked),
+            super::pbs_output::ModeOfInheritance::YLinked
+        );
+        assert_eq!(
+            Into::<super::pbs_output::ModeOfInheritance>::into(
+                super::ModeOfInheritance::Mitochondrial
+            ),
+            super::pbs_output::ModeOfInheritance::Mitochondrial
+        );
+    }
+
+    #[test]
+    fn load_hgnc_to_inheritance_map() -> Result<(), anyhow::Error> {
+        let path = std::path::Path::new("tests/seqvars/query/db/hpo");
+        let map = super::load_hgnc_to_inheritance_map(&path)?;
+
+        assert_eq!(map.len(), 4599);
+        insta::assert_yaml_snapshot!(&map[0..5]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_phenotype_to_genes_load_entries() -> Result<(), anyhow::Error> {
+        let path = std::path::Path::new("tests/seqvars/query/db/hpo/phenotype_to_genes.txt");
+        let entries = super::phenotype_to_genes::load_entries(&path)?;
+
+        assert_eq!(entries.len(), 988720);
+        insta::assert_yaml_snapshot!(&entries[0..5]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_hgnc_to_xlink_load_entries() -> Result<(), anyhow::Error> {
+        let path = std::path::Path::new("tests/seqvars/query/db/hpo/hgnc_xlink.tsv");
+        let map = super::hgnc_xlink::load_entries(&path)?;
+
+        assert_eq!(map.len(), 43839);
+        insta::assert_yaml_snapshot!(&map[0..5]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_load_ncbi_to_hgnc() -> Result<(), anyhow::Error> {
+        let path = std::path::Path::new("tests/seqvars/query/db/hpo/hgnc_xlink.tsv");
+        let map = super::hgnc_xlink::load_ncbi_to_hgnc(&path)?;
+
+        assert_eq!(map.len(), 43792);
+        assert_eq!(map.get(&1), Some(&vec!["HGNC:5".to_string()]));
+        assert_eq!(map.get(&2), Some(&vec!["HGNC:7".to_string()]));
+
+        Ok(())
+    }
+}

--- a/src/seqvars/query/mod.rs
+++ b/src/seqvars/query/mod.rs
@@ -765,7 +765,7 @@ mod gene_related_annotation {
             .map(|gene_record| pbs_output::GeneRelatedPhenotypes {
                 is_acmg_sf: gene_record.acmg_sf.is_some(),
                 is_disease_gene: gene_record.omim.is_some() || gene_record.orpha.is_some(),
-                modes_of_inheritance: mois
+                mode_of_inheritances: mois
                     .cloned()
                     .unwrap_or_default()
                     .into_iter()

--- a/src/seqvars/query/mod.rs
+++ b/src/seqvars/query/mod.rs
@@ -1,6 +1,7 @@
 //! Code implementing the "seqvars query" sub command.
 
 pub mod annonars;
+pub mod hpo;
 pub mod interpreter;
 pub mod schema;
 pub mod sorting;
@@ -712,6 +713,7 @@ impl WithSeqvarAndAnnotator for pbs_output::GeneRelatedAnnotation {
                 let gene_record = annotator
                     .query_genes(&hgnc_id)
                     .map_err(|e| anyhow::anyhow!("problem querying genes database: {}", e))?;
+                let mois = annotator.hgnc_to_moi.get(&hgnc_id);
 
                 return Ok(Self {
                     identity: Some(pbs_output::GeneIdentity {
@@ -719,7 +721,7 @@ impl WithSeqvarAndAnnotator for pbs_output::GeneRelatedAnnotation {
                         gene_symbol: ann.gene_symbol.clone(),
                     }),
                     consequences: gene_related_annotation::consequences(ann)?,
-                    phenotypes: gene_related_annotation::phenotypes(&gene_record),
+                    phenotypes: gene_related_annotation::phenotypes(&gene_record, mois),
                     constraints: gene_related_annotation::constraints(&gene_record)?,
                 });
             }
@@ -756,12 +758,19 @@ mod gene_related_annotation {
 
     pub(crate) fn phenotypes(
         gene_record: &Option<::annonars::pbs::genes::base::Record>,
+        mois: Option<&indexmap::IndexSet<hpo::ModeOfInheritance>>,
     ) -> Option<pbs_output::GeneRelatedPhenotypes> {
         gene_record
             .as_ref()
             .map(|gene_record| pbs_output::GeneRelatedPhenotypes {
                 is_acmg_sf: gene_record.acmg_sf.is_some(),
                 is_disease_gene: gene_record.omim.is_some() || gene_record.orpha.is_some(),
+                modes_of_inheritance: mois
+                    .cloned()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|moi| Into::<pbs_output::ModeOfInheritance>::into(moi) as i32)
+                    .collect::<Vec<_>>(),
             })
     }
 

--- a/src/seqvars/query/snapshots/varfish_server_worker__seqvars__query__hpo__test__hgnc_to_xlink_load_entries.snap
+++ b/src/seqvars/query/snapshots/varfish_server_worker__seqvars__query__hpo__test__hgnc_to_xlink_load_entries.snap
@@ -1,0 +1,24 @@
+---
+source: src/seqvars/query/hpo.rs
+expression: "&map[0..5]"
+---
+- hgnc_id: "HGNC:5"
+  ensembl_gene_id: ENSG00000121410
+  ncbi_gene_id: 1
+  gene_symbol: A1BG
+- hgnc_id: "HGNC:37133"
+  ensembl_gene_id: ENSG00000268895
+  ncbi_gene_id: 503538
+  gene_symbol: A1BG-AS1
+- hgnc_id: "HGNC:24086"
+  ensembl_gene_id: ENSG00000148584
+  ncbi_gene_id: 29974
+  gene_symbol: A1CF
+- hgnc_id: "HGNC:7"
+  ensembl_gene_id: ENSG00000175899
+  ncbi_gene_id: 2
+  gene_symbol: A2M
+- hgnc_id: "HGNC:27057"
+  ensembl_gene_id: ENSG00000245105
+  ncbi_gene_id: 144571
+  gene_symbol: A2M-AS1

--- a/src/seqvars/query/snapshots/varfish_server_worker__seqvars__query__hpo__test__load_hgnc_to_inheritance_map.snap
+++ b/src/seqvars/query/snapshots/varfish_server_worker__seqvars__query__hpo__test__load_hgnc_to_inheritance_map.snap
@@ -1,0 +1,15 @@
+---
+source: src/seqvars/query/hpo.rs
+expression: "&map[0..5]"
+---
+- - "HGNC:7114"
+  - - AutosomalDominant
+- - "HGNC:19309"
+  - - AutosomalDominant
+- - "HGNC:16391"
+  - - AutosomalRecessive
+- - "HGNC:1966"
+  - - AutosomalDominant
+    - AutosomalRecessive
+- - "HGNC:4241"
+  - - AutosomalRecessive

--- a/src/seqvars/query/snapshots/varfish_server_worker__seqvars__query__hpo__test__phenotype_to_genes_load_entries.snap
+++ b/src/seqvars/query/snapshots/varfish_server_worker__seqvars__query__hpo__test__phenotype_to_genes_load_entries.snap
@@ -1,0 +1,24 @@
+---
+source: src/seqvars/query/hpo.rs
+expression: "&entries[0..5]"
+---
+- ncbi_gene_id: 3081
+  gene_symbol: HGD
+  hpo_id: "HP:0008775"
+  hpo_name: Abnormal prostate morphology
+- ncbi_gene_id: 695
+  gene_symbol: BTK
+  hpo_id: "HP:0008775"
+  hpo_name: Abnormal prostate morphology
+- ncbi_gene_id: 695
+  gene_symbol: BTK
+  hpo_id: "HP:0008775"
+  hpo_name: Abnormal prostate morphology
+- ncbi_gene_id: 1493
+  gene_symbol: CTLA4
+  hpo_id: "HP:0008775"
+  hpo_name: Abnormal prostate morphology
+- ncbi_gene_id: 26191
+  gene_symbol: PTPN22
+  hpo_id: "HP:0008775"
+  hpo_name: Abnormal prostate morphology

--- a/src/strucvars/aggregate/cli.rs
+++ b/src/strucvars/aggregate/cli.rs
@@ -84,7 +84,7 @@ async fn split_input_by_chrom_and_sv_type(
                 .expect("no file for chrom/sv_type");
             #[allow(clippy::needless_borrows_for_generic_args)]
             to_writer(&mut tmp_file, &input_record)?;
-            tmp_file.write_all(&[b'\n'])?;
+            tmp_file.write_all(b"\n")?;
 
             // Write out progress indicator every 60 seconds.
             if prev.elapsed().as_secs() >= 60 {

--- a/tests/strucvars/query/db/hpo/hgnc_xlink.tsv
+++ b/tests/strucvars/query/db/hpo/hgnc_xlink.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36fea776c169438bf476b25b21a2dbf5a3ae0451aa6aef2126bd9aac8fc54282
+size 1811518

--- a/tests/strucvars/query/db/hpo/phenotype_to_genes.txt
+++ b/tests/strucvars/query/db/hpo/phenotype_to_genes.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41aef588fbcdeaa3c36b236827a384f9b2f8add720fe9cdf2dd9a7120791643e
+size 49631290


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new enumeration for modes of inheritance, enhancing genetic data representation.
	- Added functionality for accessing and processing Human Phenotype Ontology (HPO) information.
	- Enhanced the `Annotator` with a mapping from HGNC gene IDs to modes of inheritance.
	- Updated genetic variant annotation methods to include modes of inheritance in outputs.

- **Bug Fixes**
	- Corrected documentation comments for clarity.

- **Chores**
	- Simplified file writing syntax in the CLI component.
	- Added a substantial data file for phenotype-to-gene mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->